### PR TITLE
Add HTTPS custom domain and IAM role in separate stack

### DIFF
--- a/deploy-iam.sh
+++ b/deploy-iam.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+STACK=${STACK-'p5-replay-iam'}
+
+TEMPLATE=iam.yml
+aws cloudformation deploy \
+  --template-file ${TEMPLATE} \
+  --capabilities CAPABILITY_IAM \
+  --stack-name ${STACK} \
+  "$@"

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,5 +13,4 @@ aws cloudformation package \
 
 aws cloudformation deploy \
   --template-file ${OUTPUT_TEMPLATE} \
-  --stack-name ${STACK} \
-  --capabilities CAPABILITY_IAM
+  --stack-name ${STACK}

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,4 +13,5 @@ aws cloudformation package \
 
 aws cloudformation deploy \
   --template-file ${OUTPUT_TEMPLATE} \
-  --stack-name ${STACK}
+  --stack-name ${STACK} \
+  "$@"

--- a/iam.yml
+++ b/iam.yml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  p5-replay service IAM role.
+  Note: CAPABILITY_IAM capability is required to deploy this stack.
+
+Parameters:
+  DestinationBucketName:
+    Type: String
+  SourceBucketName:
+    Type: String
+
+Resources:
+  p5ReplayRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: ['sts:AssumeRole']
+            Effect: Allow
+            Principal: {Service: [lambda.amazonaws.com]}
+      Path: /
+      Policies:
+        - PolicyName: p5ReplayRolePolicy
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - "s3:GetObject"
+                - "s3:ListBucket"
+                - "s3:GetBucketLocation"
+                - "s3:GetObjectVersion"
+                - "s3:PutObject"
+                - "s3:GetLifecycleConfiguration"
+                - "s3:PutLifecycleConfiguration"
+                - "s3:DeleteObject"
+              Resource:
+                - "arn:aws:s3:::${SourceBucketName}"
+                - "arn:aws:s3:::${SourceBucketName}/*"
+                - "arn:aws:s3:::${DestinationBucketName}"
+                - "arn:aws:s3:::${DestinationBucketName}/*"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+Outputs:
+  p5ReplayRole:
+    Description: P5 Replay Role ARN
+    Value: !GetAtt p5ReplayRole.Arn
+    Export: {Name: p5ReplayRole}

--- a/template.yml
+++ b/template.yml
@@ -5,10 +5,14 @@ Description: p5-replay service
 Parameters:
   DestinationBucketName:
     Type: String
-    Default: cdo-p5-replay-destination
   SourceBucketName:
     Type: String
-    Default: cdo-p5-replay-source
+  HostedZoneName:
+    Type: String
+    AllowedPattern: '.*\.$'
+    ConstraintDescription: Must end with trailing dot `.`
+  DomainName:
+    Type: String
 
 Globals:
   Function:
@@ -56,7 +60,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: handler.runTest
-      Role: !ImportValue IAM-p5ReplayRoleARN
+      Role: !ImportValue p5ReplayRole
       Events:
         Get:
           Type: Api
@@ -68,7 +72,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: handler.render
-      Role: !ImportValue IAM-p5ReplayRoleARN
+      Role: !ImportValue p5ReplayRole
       Events:
         Post:
           Type: Api
@@ -80,10 +84,38 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: handler.renderFromS3
-      Role: !ImportValue IAM-p5ReplayRoleARN
+      Role: !ImportValue p5ReplayRole
       Events:
         Created:
           Type: S3
           Properties:
             Bucket: !Ref SourceBucket
             Events: 's3:ObjectCreated:*'
+  APICertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS
+  APIDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      CertificateArn: !Ref APICertificate
+      DomainName: !Ref DomainName
+  APIBasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      DomainName: !Ref APIDomainName
+      RestApiId: !Ref ServerlessRestApi
+      Stage: Prod
+  APIDomain:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: !Ref HostedZoneName
+      Name: !Ref DomainName
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt APIDomainName.DistributionDomainName
+        HostedZoneId: !GetAtt APIDomainName.DistributionHostedZoneId
+Outputs:
+  ApiUrl:
+    Value: !Sub "https://${DomainName}"

--- a/template.yml
+++ b/template.yml
@@ -56,8 +56,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: handler.runTest
-      Policies:
-        - S3CrudPolicy: {BucketName: !Ref DestinationBucketName}
+      Role: !ImportValue IAM-p5ReplayRoleARN
       Events:
         Get:
           Type: Api
@@ -69,8 +68,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: handler.render
-      Policies:
-        - S3CrudPolicy: {BucketName: !Ref DestinationBucketName}
+      Role: !ImportValue IAM-p5ReplayRoleARN
       Events:
         Post:
           Type: Api
@@ -82,9 +80,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: handler.renderFromS3
-      Policies:
-        - S3CrudPolicy: {BucketName: !Ref DestinationBucketName}
-        - S3CrudPolicy: {BucketName: !Ref SourceBucketName}
+      Role: !ImportValue IAM-p5ReplayRoleARN
       Events:
         Created:
           Type: S3


### PR DESCRIPTION
* Add additional resources to deploy the service to a custom HTTPS domain
* Add stack template for deploying IAM role in a separate stack, so the service can be deployed/updated separately without requiring access to IAM permissions
* Remove default parameters from stack. Instead, they should be optionally provided to the stack via `--parameter-overrides` on initial creation or on any future updates, e.g.:

```
./deploy-iam.sh \
  --parameter-overrides \
    SourceBucketName=MySourceBucket \
    DestinationBucketName=MyDestinationBucket
```

When not provided, the stack's parameters will be re-used.