### PR TITLE
add GitHub-CI CodeBuild/CodePipeline stack

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,208 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: p5-replay Continuous Integration pipeline
+
+Parameters:
+  ArtifactBucket:
+    Type: String
+    Description: Name of existing S3 bucket for storing pipeline artifacts
+  TemplateBucket:
+    Type: String
+    Description: Name of existing S3 bucket for storing CloudFormation template artifacts
+  GitHubOwner:
+    Type: String
+    Description: GitHub repository owner
+  GitHubRepo:
+    Type: String
+    Default: p5-replay
+    Description: GitHub repository name
+  GitHubBranch:
+    Type: String
+    Default: master
+    Description: GitHub repository branch
+  GitHubToken:
+    Type: String
+    Description: GitHub repository OAuth token
+    NoEcho: true
+  CodePipelineServiceRoleName:
+    Type: String
+    Description: CodePipeline Service Role name
+    Default: AWS-CodePipeline-Service
+  StackName:
+    Type: String
+    Description: Application stack name
+    Default: p5-replay
+  StagingStackName:
+    Type: String
+    Description: Staging application stack name
+    Default: p5-replay-staging
+
+Resources:
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${CodePipelineServiceRoleName}"
+      ArtifactStore:
+        Type: S3
+        Location: !Ref ArtifactBucket
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Source
+              RunOrder: 1
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Version: 1
+                Provider: GitHub
+              Configuration:
+                Owner: !Ref GitHubOwner
+                Repo: !Ref GitHubRepo
+                Branch: !Ref GitHubBranch
+                OAuthToken: !Ref GitHubToken
+                PollForSourceChanges: false
+              OutputArtifacts: [Name: Repo]
+        - Name: Build
+          Actions:
+            - Name: Build
+              RunOrder: 1
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              InputArtifacts: [Name: Repo]
+              Configuration:
+                ProjectName: !Ref Build
+              OutputArtifacts: [Name: Package]
+        - Name: Staging
+          Actions:
+            - Name: CreateChangeSet
+              RunOrder: 1
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              InputArtifacts: [Name: Package]
+              Configuration:
+                ActionMode: CHANGE_SET_REPLACE
+                ChangeSetName: StagingChangeSet
+                RoleArn: !ImportValue p5ReplayCFNRole
+                StackName: !Ref StagingStackName
+                TemplatePath: Package::output.yml
+                TemplateConfiguration: Package::configuration-staging.json
+              OutputArtifacts: [Name: StagingChangeSet]
+            - Name: ExecuteChangeSet
+              RunOrder: 2
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              InputArtifacts: [Name: StagingChangeSet]
+              Configuration:
+                ActionMode: CHANGE_SET_EXECUTE
+                ChangeSetName: StagingChangeSet
+                StackName: !Ref StagingStackName
+        - Name: Production
+          Actions:
+            - Name: CreateChangeSet
+              RunOrder: 1
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              InputArtifacts: [Name: Package]
+              Configuration:
+                ActionMode: CHANGE_SET_REPLACE
+                ChangeSetName: ProdChangeSet
+                RoleArn: !ImportValue p5ReplayCFNRole
+                StackName: !Ref StackName
+                TemplatePath: Package::output.yml
+                TemplateConfiguration: Package::configuration.json
+              OutputArtifacts: [Name: ProdChangeSet]
+            - Name: ApproveChangeSet
+              RunOrder: 2
+              ActionTypeId:
+                Category: Approval
+                Owner: AWS
+                Provider: Manual
+                Version: 1
+              Configuration:
+                NotificationArn: !Ref BuildApprovalSNS
+                CustomData: !Sub "A new ${StackName} build is ready for deploy."
+            - Name: ExecuteChangeSet
+              RunOrder: 3
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              InputArtifacts: [Name: ProdChangeSet]
+              Configuration:
+                ActionMode: CHANGE_SET_EXECUTE
+                ChangeSetName: ProdChangeSet
+                StackName: !Ref StackName
+  Webhook:
+    Type: AWS::CodePipeline::Webhook
+    Properties:
+      AuthenticationConfiguration:
+        SecretToken: !Ref AWS::AccountId
+      Filters:
+        - JsonPath: "$.ref"
+          MatchEquals: refs/heads/{Branch}
+      Authentication: GITHUB_HMAC
+      TargetPipeline: !Ref Pipeline
+      TargetAction: Source
+      Name: p5-replay-webhook
+      TargetPipelineVersion: !GetAtt Pipeline.Version
+      RegisterWithThirdParty: true
+  Build:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: aws/codebuild/docker:17.09.0
+        Type: LINUX_CONTAINER
+      ServiceRole: !ImportValue p5ReplayCodeBuildRole
+      Source:
+        Type: CODEPIPELINE
+        GitCloneDepth: 1
+        BuildSpec: !Sub |
+          version: 0.2
+          env:
+            variables:
+              REPO: ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${DockerRepo}
+              REF_NAME: ${GitHubBranch}
+              TEMPLATE_BUCKET: ${TemplateBucket}
+              OUTPUT_TEMPLATE: output.yml
+              STACK: ${StackName}
+              STAGING_STACK: ${StackName}
+              TEMPLATE_CONFIG: configuration.json
+              STAGING_TEMPLATE_CONFIG: configuration-staging.json
+          phases:
+            install:
+              commands:
+                - apt-get update && apt-get install -y jq
+            pre_build:
+              commands:
+                - docker version
+                - $(aws ecr get-login --no-include-email)
+            build:
+              commands:
+                - /bin/bash ./package.sh
+            post_build:
+              commands:
+                - docker push $REPO
+          artifacts:
+            files:
+              - output.yml
+              - configuration.json
+              - configuration-staging.json
+  DockerRepo:
+    Type: AWS::ECR::Repository
+  BuildApprovalSNS:
+    Type: AWS::SNS::Topic

--- a/deploy-ci.sh
+++ b/deploy-ci.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+
+# Deploys the CI-service CloudFormation stack.
+
+STACK=${STACK-'p5-replay-ci'}
+
+TEMPLATE=ci.yml
+aws cloudformation deploy \
+  --template-file ${TEMPLATE} \
+  --stack-name ${STACK} \
+  "$@"

--- a/deploy-iam.sh
+++ b/deploy-iam.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -xe
 
+# Deploys IAM-permissions CloudFormation stack.
+# Requires admin access to create/modify IAM roles.
+
 STACK=${STACK-'p5-replay-iam'}
 
 TEMPLATE=iam.yml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,10 +1,14 @@
 #!/bin/bash -xe
 
-S3_BUCKET=${S3_BUCKET-'cf-templates-p9nfb0gyyrpf-us-east-1'}
-STACK=${STACK-'p5-replay'}
+# Deploys API service CloudFormation stack.
 
+S3_BUCKET=${S3_BUCKET?Required}
+
+STACK=${STACK-'p5-replay'}
 TEMPLATE=template.yml
 OUTPUT_TEMPLATE=$(mktemp)
+
+./build.sh
 
 aws cloudformation package \
   --template-file ${TEMPLATE} \

--- a/iam.yml
+++ b/iam.yml
@@ -8,6 +8,12 @@ Parameters:
     Type: String
   SourceBucketName:
     Type: String
+  ArtifactBucket:
+    Type: String
+    Description: Name of existing S3 bucket for storing pipeline artifacts
+  TemplateBucket:
+    Type: String
+    Description: Name of existing S3 bucket for storing CloudFormation template artifacts
 
 Resources:
   p5ReplayRole:
@@ -34,15 +40,86 @@ Resources:
                 - "s3:PutLifecycleConfiguration"
                 - "s3:DeleteObject"
               Resource:
-                - "arn:aws:s3:::${SourceBucketName}"
-                - "arn:aws:s3:::${SourceBucketName}/*"
-                - "arn:aws:s3:::${DestinationBucketName}"
-                - "arn:aws:s3:::${DestinationBucketName}/*"
+                - !Sub "arn:aws:s3:::${SourceBucketName}*"
+                - !Sub "arn:aws:s3:::${DestinationBucketName}*"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 
+  p5ReplayCFNRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: ['sts:AssumeRole']
+            Effect: Allow
+            Principal: {Service: [cloudformation.amazonaws.com]}
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+        - PolicyName: ManageResourcesAccess
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "apigateway:*"
+                  - "lambda:*"
+                  - "cloudformation:*"
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                Resource:
+                  - !Sub "arn:aws:s3:::${TemplateBucket}/*"
+              - Effect: Allow
+                Action:
+                  - "iam:PassRole"
+                Resource:
+                  - !GetAtt p5ReplayRole.Arn
+  p5ReplayCodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: ['sts:AssumeRole']
+            Effect: Allow
+            Principal: {Service: [codebuild.amazonaws.com]}
+        Version: '2012-10-17'
+      Path: /service-role/
+      Policies:
+        - PolicyName: CodeBuildResourcesAccess
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource:
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*"
+              - Effect: Allow
+                Action:
+                  - "s3:*"
+                Resource:
+                  - !Sub "arn:aws:s3:::${ArtifactBucket}/*"
+                  - !Sub "arn:aws:s3:::${ArtifactBucket}"
+                  - !Sub "arn:aws:s3:::${TemplateBucket}/*"
+                  - !Sub "arn:aws:s3:::${TemplateBucket}"
+              - Effect: Allow
+                Action:
+                  - "cloudformation:DescribeStacks"
+                Resource: '*'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser'
 Outputs:
   p5ReplayRole:
     Description: P5 Replay Role ARN
     Value: !GetAtt p5ReplayRole.Arn
     Export: {Name: p5ReplayRole}
+  p5ReplayCFNRole:
+    Description: P5 Replay CFN Role ARN
+    Value: !GetAtt p5ReplayCFNRole.Arn
+    Export: {Name: p5ReplayCFNRole}
+  p5ReplayCodeBuildRole:
+    Description: P5 Replay CodeBuild Role ARN
+    Value: !GetAtt p5ReplayCodeBuildRole.Arn
+    Export: {Name: p5ReplayCodeBuildRole}

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+# Package template for CodePipeline's CloudFormation-Deploy action.
+
+# Required environment variables:
+STACK=${STACK?Required}
+STAGING_STACK=${STACK?Required}
+OUTPUT_TEMPLATE=${OUTPUT_TEMPLATE?Required}
+TEMPLATE_CONFIG=${TEMPLATE_CONFIG?Required}
+STAGING_TEMPLATE_CONFIG=${STAGING_TEMPLATE_CONFIG?Required}
+TEMPLATE_BUCKET=${TEMPLATE_BUCKET?Required}
+
+/bin/bash ./build.sh
+
+aws cloudformation package \
+  --template-file template.yml \
+  --s3-bucket ${TEMPLATE_BUCKET} \
+  --output-template-file ${OUTPUT_TEMPLATE} \
+
+# Query existing parameter values for reuse in CodePipeline configuration.
+JQ_FILTER='{Parameters: .Stacks[].Parameters | map({(.ParameterKey): .ParameterValue}) | add}'
+
+aws cloudformation describe-stacks --stack-name ${STACK} | \
+  jq ${JQ_FILTER} \
+    > ${TEMPLATE_CONFIG}
+
+aws cloudformation describe-stacks --stack-name ${STAGING_STACK} | \
+  jq ${JQ_FILTER} \
+    > ${STAGING_TEMPLATE_CONFIG}


### PR DESCRIPTION
Build Docker artifacts using CodeBuild, deploy updated CloudFormation stacks using CodePipeline.

Pipeline includes a `Staging` codepipeline stage which deploys the updated package to the `staging` stack, followed by a `Production` codepipeline stage which creates a CloudFormation change set, waits on manual approval, then deploys the same package to the production stack.