### PR TITLE
add Slack integrations for CI CodePipeline

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
 Description: p5-replay Continuous Integration pipeline
 
 Parameters:
@@ -35,11 +36,30 @@ Parameters:
     Type: String
     Description: Staging application stack name
     Default: p5-replay-staging
+  SlackApprovalWebhookUrl:
+    Type: String
+    NoEcho: true
+    Description: Slack Webhook URL for manual approval actions
+  SlackSigningSecret:
+    Type: String
+    NoEcho: true
+    Description: Slack signing secret for manual approval actions
+  SlackPipelineWebhookUrl:
+    Type: String
+    NoEcho: true
+    Description: Slack Webhook URL for pipeline event notifications
+
+Globals:
+  Function:
+    Runtime: nodejs8.10
+    Timeout: 10
+    MemorySize: 3008
 
 Resources:
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
+      Name: !Ref StackName
       RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/${CodePipelineServiceRoleName}"
       ArtifactStore:
         Type: S3
@@ -76,7 +96,7 @@ Resources:
               OutputArtifacts: [Name: Package]
         - Name: Staging
           Actions:
-            - Name: CreateChangeSet
+            - Name: Prepare
               RunOrder: 1
               ActionTypeId:
                 Category: Deploy
@@ -92,7 +112,7 @@ Resources:
                 TemplatePath: Package::output.yml
                 TemplateConfiguration: Package::configuration-staging.json
               OutputArtifacts: [Name: StagingChangeSet]
-            - Name: ExecuteChangeSet
+            - Name: Deploy
               RunOrder: 2
               ActionTypeId:
                 Category: Deploy
@@ -106,7 +126,7 @@ Resources:
                 StackName: !Ref StagingStackName
         - Name: Production
           Actions:
-            - Name: CreateChangeSet
+            - Name: Prepare
               RunOrder: 1
               ActionTypeId:
                 Category: Deploy
@@ -122,7 +142,7 @@ Resources:
                 TemplatePath: Package::output.yml
                 TemplateConfiguration: Package::configuration.json
               OutputArtifacts: [Name: ProdChangeSet]
-            - Name: ApproveChangeSet
+            - Name: Approval
               RunOrder: 2
               ActionTypeId:
                 Category: Approval
@@ -131,8 +151,8 @@ Resources:
                 Version: 1
               Configuration:
                 NotificationArn: !Ref BuildApprovalSNS
-                CustomData: !Sub "A new ${StackName} build is ready for deploy."
-            - Name: ExecuteChangeSet
+                CustomData: !Sub "${StackName} build awaiting approval to Production."
+            - Name: Deploy
               RunOrder: 3
               ActionTypeId:
                 Category: Deploy
@@ -206,3 +226,56 @@ Resources:
     Type: AWS::ECR::Repository
   BuildApprovalSNS:
     Type: AWS::SNS::Topic
+  ApprovalRequest:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./ciApproval
+      Handler: request.requestApproval
+      Role: !ImportValue p5ReplayRole
+      Environment:
+        Variables:
+          SLACK_WEBHOOK_URL: !Ref SlackApprovalWebhookUrl
+          STACK_NAME: !Ref StackName
+      Events:
+        ApprovalRequest:
+          Type: SNS
+          Properties:
+            Topic: !Ref BuildApprovalSNS
+  ApprovalRespond:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./ciApproval
+      Handler: response.respondApproval
+      Role: !ImportValue p5ReplayRole
+      Environment:
+        Variables:
+          SLACK_SIGNING_SECRET: !Ref SlackSigningSecret
+      Events:
+        ApprovalRespond:
+          Type: Api
+          Properties:
+            Path: /
+            Method: post
+  SlackPipelineEvent:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./ciApproval
+      Handler: stateChange.handler
+      Role: !ImportValue p5ReplayRole
+      Environment:
+        Variables:
+          SLACK_WEBHOOK_URL: !Ref SlackPipelineWebhookUrl
+      Events:
+        Pipeline:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              detail-type:
+                - CodePipeline Stage Execution State Change
+              detail:
+                pipeline:
+                  - !Ref Pipeline
+Outputs:
+  ApprovalResponseUrl:
+    Description: "Approval Response URL"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"

--- a/ciApproval/request.js
+++ b/ciApproval/request.js
@@ -1,0 +1,121 @@
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
+const STACK_NAME = process.env.STACK_NAME;
+
+const https = require('https');
+const url = require('url');
+const requestOptions = url.parse(SLACK_WEBHOOK_URL);
+requestOptions.method = 'POST';
+requestOptions.headers = {
+  'Content-Type': 'application/json'
+};
+
+const AWS = require('aws-sdk');
+const codePipeline = new AWS.CodePipeline();
+const cloudFormation = new AWS.CloudFormation();
+
+/**
+ * Lambda function for creating a CI-approval Slack Message Button in response to
+ * a CodePipeline Manual Approval Notification SNS message.
+ *
+ * AWS APIs invoked:
+ * - codepipeline:GetPipelineState
+ * - codepipeline:GetPipelineExecution
+ * - cloudformation:DescribeStacks
+ *
+ * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodePipeline.html#getPipelineState-property
+ * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodePipeline.html#getPipelineExecution-property
+ * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudFormation.html#describeStacks-property
+ * @see https://docs.aws.amazon.com/codepipeline/latest/userguide/approvals-json-format.html
+ */
+module.exports.requestApproval = async function (event, context, callback) {
+  console.log(`Request received: ${JSON.stringify(event)}`);
+  let req = https.request(requestOptions, function (res) {
+    if (res.statusCode === 200) {
+      callback(null, 'posted to slack');
+    } else {
+      callback('status code: ' + res.statusCode);
+    }
+  });
+
+  req.on('error', function (e) {
+    console.log('problem with request: ' + e.message);
+    callback(e.message);
+  });
+
+  const data = JSON.parse(event.Records[0].Sns.Message);
+  const token = data.approval.token;
+  const pipelineName = data.approval.pipelineName;
+  const stage = data.approval.stageName;
+  const action = data.approval.actionName;
+
+  // Lookup the commit URL and ID from the pipeline execution state.
+  const state = await codePipeline.getPipelineState({name: pipelineName}).promise();
+  const stageState = state.stageStates.find((state) => state.stageName === stage);
+  const executionId = stageState.latestExecution.pipelineExecutionId;
+  const execution = await codePipeline.getPipelineExecution({
+    pipelineName: pipelineName,
+    pipelineExecutionId: executionId
+  }).promise();
+  const artifact = execution.pipelineExecution.artifactRevisions[0];
+
+  const revisionUrl = artifact.revisionUrl;
+  const revisionId = artifact.revisionId.substring(0, 7);
+
+  // Lookup the previous and current stage URLs from the CloudFormation stack outputs.
+  const stack = await cloudFormation.describeStacks({StackName: STACK_NAME}).promise();
+  const currentUrl = stack.Stacks[0].Outputs.find((o) => o.OutputKey === 'ApiUrl').OutputValue;
+
+  const emoji = {
+    true: ':rocket:',
+    false: ':exclamation:'
+  };
+
+  const slackMessage = {
+    text: `Build <${revisionUrl}|${STACK_NAME}@${revisionId}> awaiting approval to <${currentUrl}|${stage}>.`,
+    attachments: [
+      {
+        fallback: "Unable to approve from fallback",
+        callback_id: "ci_approval",
+        color: "#3AA3E3",
+        attachment_type: "default",
+        actions: [
+          {
+            name: action,
+            text: `${emoji[true]} Approve`,
+            style: "primary",
+            type: "button",
+            value: JSON.stringify({
+              approve: true,
+              approvalText: emoji[true],
+              codePipelineToken: token,
+              codePipelineName: pipelineName,
+              stage: stage,
+              action: action
+            }),
+            confirm: {
+              title: "Are you sure?",
+              text: `Approve to ${stage} ${emoji[true]}`,
+              ok_text: `Yes`,
+              dismiss_text: "No"
+            }
+          },
+          {
+            name: action,
+            text: `${emoji[false]} Reject`,
+            type: "button",
+            value: JSON.stringify({
+              approve: false,
+              approvalText: emoji[false],
+              codePipelineToken: token,
+              codePipelineName: pipelineName,
+              stage: stage,
+              action: action
+            })
+          }
+        ]
+      }
+    ]
+  };
+  req.write(JSON.stringify(slackMessage));
+  req.end();
+};

--- a/ciApproval/response.js
+++ b/ciApproval/response.js
@@ -1,0 +1,63 @@
+const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
+
+const crypto = require('crypto');
+const querystring = require('querystring');
+const AWS = require('aws-sdk');
+const codePipeline = new AWS.CodePipeline();
+
+/**
+ * Lambda function for responding to a CI-approval Slack Message Button event.
+ * Calls codepipeline:PutApprovalResult, and returns the updated Slack message in the response.
+ * @see https://api.slack.com/docs/message-buttons#responding_to_message_actions
+ * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodePipeline.html#putApprovalResult-property
+ */
+module.exports.respondApproval = function(event, context, callback) {
+  console.log(`Request received: ${JSON.stringify(event)}`);
+  verifyMessage(event.headers, event.body, callback);
+  const payload = JSON.parse(querystring.parse(event.body).payload);
+  const actionDetails = JSON.parse(payload.actions[0].value);
+  const user = payload.user;
+  const status = actionDetails.approve ? "Approved" : "Rejected";
+  codePipeline.putApprovalResult({
+    pipelineName: actionDetails.codePipelineName,
+    stageName: actionDetails.stage,
+    actionName: actionDetails.action,
+    result: {
+      summary: `${status} by @${user.name} via Slack`,
+      status: status
+    },
+    token: actionDetails.codePipelineToken
+  }).promise()
+    .then((data)=> callback(null, {
+      statusCode: 200,
+      body: JSON.stringify({
+        text: payload.original_message.text.replace('awaiting approval', status),
+        attachments: [{
+          text: actionDetails.approvalText,
+          color: actionDetails.approve ? "good" : "danger",
+          footer: `<@${user.id}>`,
+          ts: payload.action_ts
+        }],
+        replace_original: true
+      })
+    }))
+    .catch((e) => callback(e));
+};
+
+/**
+ * Verify Slack message using signed secret.
+ * @see https://api.slack.com/docs/verifying-requests-from-slack
+ */
+function verifyMessage(headers, body, callback) {
+  const baseString = `v0:${headers['X-Slack-Request-Timestamp']}:${body}`;
+  const hash = 'v0=' + crypto.createHmac('sha256', SLACK_SIGNING_SECRET)
+    .update(baseString)
+    .digest('hex');
+  const retrievedSignature = headers['X-Slack-Signature'];
+  if (hash !== retrievedSignature) {
+    callback(null, {
+      statusCode: 401,
+      body: 'Signature verification failed, Ignoring message'
+    });
+  }
+}

--- a/ciApproval/stateChange.js
+++ b/ciApproval/stateChange.js
@@ -1,0 +1,77 @@
+// Send Auto Scaling notifications to production channel.
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
+
+const https = require('https');
+const url = require('url');
+const slack_req_opts = url.parse(SLACK_WEBHOOK_URL);
+slack_req_opts.method = 'POST';
+slack_req_opts.headers = {
+  'Content-Type': 'application/json'
+};
+
+/**
+ * Lambda function for forwarding a CloudWatch Event SNS message to Slack.
+ */
+exports.handler = function (event, context, callback) {
+  var req = https.request(slack_req_opts, function (res) {
+    if (res.statusCode === 200) {
+      callback(null, 'posted to slack');
+    } else {
+      callback('status code: ' + res.statusCode);
+    }
+  });
+
+  req.on('error', function (e) {
+    console.log('problem with request: ' + e.message);
+    callback(e.message);
+  });
+
+  var message;
+  var detail = event.detail;
+  var type = event['detail-type'];
+  switch (event.source) {
+    case "aws.codepipeline":
+      message = codePipeline(detail, type);
+      break;
+    default:
+      message = {};
+      break;
+  }
+  req.write(JSON.stringify(message));
+  req.end();
+};
+
+/**
+ * Formats a Slack-message JSON object from a CodePipeline SNS-detail object.
+ * @see https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html#create-cloudwatch-notifications
+ * @param detail JSON object with event details. Example:
+   {
+      "pipeline": "myPipeline",
+      "version": "1",
+      "execution-id": 'execution_Id',
+      "stage": "Prod",
+      "state": "STARTED",
+      "type": {
+        "owner": "AWS",
+        "category": "Deploy",
+        "provider": "CodeDeploy",
+        "version": 1
+      }
+    }
+ * @param type detail-type string.
+ */
+function codePipeline(detail, type) {
+  const stateColors = {
+    STARTED: 'warning',
+    SUCCEEDED: 'good',
+    FAILED: 'danger',
+    CANCELED: 'danger'
+  };
+
+  return {
+    attachments: [{
+      title: `[${detail.pipeline}] ${detail.stage} ${detail.state.toLowerCase()}`,
+      color: stateColors[detail.state],
+    }]
+  };
+}

--- a/deploy-ci.sh
+++ b/deploy-ci.sh
@@ -2,10 +2,18 @@
 
 # Deploys the CI-service CloudFormation stack.
 
+S3_BUCKET=${S3_BUCKET?Required}
 STACK=${STACK-'p5-replay-ci'}
 
 TEMPLATE=ci.yml
-aws cloudformation deploy \
+OUTPUT_TEMPLATE=$(mktemp)
+
+aws cloudformation package \
   --template-file ${TEMPLATE} \
+  --s3-bucket ${S3_BUCKET} \
+  --output-template-file ${OUTPUT_TEMPLATE}
+
+aws cloudformation deploy \
+  --template-file ${OUTPUT_TEMPLATE} \
   --stack-name ${STACK} \
   "$@"

--- a/iam.yml
+++ b/iam.yml
@@ -29,7 +29,7 @@ Resources:
         - PolicyName: p5ReplayRolePolicy
           PolicyDocument:
             Statement:
-              Effect: Allow
+            - Effect: Allow
               Action:
                 - "s3:GetObject"
                 - "s3:ListBucket"
@@ -42,6 +42,13 @@ Resources:
               Resource:
                 - !Sub "arn:aws:s3:::${SourceBucketName}*"
                 - !Sub "arn:aws:s3:::${DestinationBucketName}*"
+            - Effect: Allow
+              Action:
+                - "codepipeline:GetPipelineState"
+                - "codepipeline:GetPipelineExecution"
+                - "codepipeline:PutApprovalResult"
+                - "cloudformation:DescribeStacks"
+              Resource: '*'
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 


### PR DESCRIPTION
This PR adds Slack integration to the CodePipeline CI setup, including:

- Interactive Button for manual-approval actions:
![image](https://user-images.githubusercontent.com/56541/47036763-078c3800-d132-11e8-8380-ccd15afc8552.png)
- Messages for stage-update CloudWatch event notifications:
![image](https://user-images.githubusercontent.com/56541/47036248-ed058f00-d130-11e8-8500-0ab6ad2ee2b0.png)

### Setup

- [Create](https://api.slack.com/apps/new) a [Slack App](https://api.slack.com/slack-apps) if one doesn't already exist. (I've created one named `Deploy`)
- Create two [Incoming Webhooks](https://api.slack.com/incoming-webhooks#getting-started), one for the CI Approval button and one for the pipeline event notifications. (These can go to two different channels, or they can just use the same webhook to go to the same channel.) Record the webhook URLs.
- Record the value of the app's [signing secret](https://api.slack.com/docs/verifying-requests-from-slack).
- Deploy the CI stack (`./deploy-ci.sh`), overriding the various parameters for initial stack creation, including the Webhook URLs and Signing Secret. (you don't need to override ones that have a default, unless you want to change them):
```
./deploy-ci.sh --parameter-overrides \
  ArtifactBucket=x \
  TemplateBucket=x \
  GitHubOwner=x \
  GitHubToken=x \
  SlackApprovalWebhookUrl=x \
  SlackSigningSecret=x \
  SlackPipelineWebhookUrl=x
```
- After the stack is deployed, check the Stack Outputs, and enter the value of the `ApprovalResponseUrl` output as the `Request URL` in the Interactive Components section of your newly-created Slack App (see [Readying your application for interactive messages](https://api.slack.com/interactive-messages#readying_app)).