### PR TITLE
updates to CI Slack integration

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -36,18 +36,20 @@ Parameters:
     Type: String
     Description: Staging application stack name
     Default: p5-replay-staging
-  SlackApprovalWebhookUrl:
+  SlackApprovalChannel:
     Type: String
-    NoEcho: true
-    Description: Slack Webhook URL for manual approval actions
+    Description: Slack channel for manual approval actions
   SlackSigningSecret:
     Type: String
     NoEcho: true
     Description: Slack signing secret for manual approval actions
-  SlackPipelineWebhookUrl:
+  SlackToken:
     Type: String
     NoEcho: true
-    Description: Slack Webhook URL for pipeline event notifications
+    Description: Slack app Oauth token
+  SlackPipelineChannel:
+    Type: String
+    Description: Slack channel ID for pipeline event notifications
 
 Globals:
   Function:
@@ -234,7 +236,8 @@ Resources:
       Role: !ImportValue p5ReplayRole
       Environment:
         Variables:
-          SLACK_WEBHOOK_URL: !Ref SlackApprovalWebhookUrl
+          SLACK_CHANNEL: !Ref SlackApprovalChannel
+          SLACK_TOKEN: !Ref SlackToken
           STACK_NAME: !Ref StackName
       Events:
         ApprovalRequest:
@@ -264,7 +267,8 @@ Resources:
       Role: !ImportValue p5ReplayRole
       Environment:
         Variables:
-          SLACK_WEBHOOK_URL: !Ref SlackPipelineWebhookUrl
+          SLACK_CHANNEL: !Ref SlackPipelineChannel
+          SLACK_TOKEN: !Ref SlackToken
       Events:
         Pipeline:
           Type: CloudWatchEvent

--- a/ciApproval/response.js
+++ b/ciApproval/response.js
@@ -11,14 +11,14 @@ const codePipeline = new AWS.CodePipeline();
  * @see https://api.slack.com/docs/message-buttons#responding_to_message_actions
  * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodePipeline.html#putApprovalResult-property
  */
-module.exports.respondApproval = function(event, context, callback) {
+module.exports.respondApproval = async function(event, context, callback) {
   console.log(`Request received: ${JSON.stringify(event)}`);
   verifyMessage(event.headers, event.body, callback);
   const payload = JSON.parse(querystring.parse(event.body).payload);
   const actionDetails = JSON.parse(payload.actions[0].value);
   const user = payload.user;
   const status = actionDetails.approve ? "Approved" : "Rejected";
-  codePipeline.putApprovalResult({
+  await codePipeline.putApprovalResult({
     pipelineName: actionDetails.codePipelineName,
     stageName: actionDetails.stage,
     actionName: actionDetails.action,
@@ -27,21 +27,17 @@ module.exports.respondApproval = function(event, context, callback) {
       status: status
     },
     token: actionDetails.codePipelineToken
-  }).promise()
-    .then((data)=> callback(null, {
-      statusCode: 200,
-      body: JSON.stringify({
-        text: payload.original_message.text.replace('awaiting approval', status),
-        attachments: [{
-          text: actionDetails.approvalText,
-          color: actionDetails.approve ? "good" : "danger",
-          footer: `<@${user.id}>`,
-          ts: payload.action_ts
-        }],
-        replace_original: true
-      })
-    }))
-    .catch((e) => callback(e));
+  }).promise();
+  const message = payload.original_message;
+  const attachment = message.attachments[0];
+  Object.assign(attachment, {
+    text: attachment.text.replace('awaiting approval', status) + ' ' + actionDetails.approvalText,
+    color: actionDetails.approve ? "good" : "danger",
+    footer: `<@${user.id}>`,
+    ts: payload.action_ts,
+    actions: []
+  });
+  callback(null, {statusCode: 200, body: JSON.stringify(message)});
 };
 
 /**

--- a/ciApproval/slackApi.js
+++ b/ciApproval/slackApi.js
@@ -1,0 +1,50 @@
+const https = require('https');
+const url = require('url');
+const querystring = require('querystring');
+
+/**
+ * Call the specified Slack API method.
+ * @param method Slack API method to call
+ * @param {Object} args arguments to pass to method
+ * @param {String} slackToken Slack OAuth token
+ * @returns {Promise} response body
+ */
+module.exports = function(method, args, slackToken) {
+  const requestOptions = url.parse(`https://slack.com/api/${method}`);
+  if (method.match('chat')) {
+    // chat.* API calls allow JSON POST requests.
+    requestOptions.method = 'POST';
+    requestOptions.headers = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${slackToken}`
+    };
+    return request(requestOptions, JSON.stringify(args));
+  } else {
+    // Other API calls require urlencoded GET requests.
+    requestOptions.method = 'GET';
+    requestOptions.headers = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+    args.token = slackToken;
+    requestOptions.path += `?${querystring.stringify(args)}`;
+    return request(requestOptions, null);
+  }
+};
+
+function request(options, body) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, (response) => {
+      if (response.statusCode < 200 || response.statusCode > 299) {
+        reject(new Error('Error, status code: ' + response.statusCode));
+      }
+      const body = [];
+      response.on('data', chunk => body.push(chunk));
+      response.on('end', () => resolve(body.join('')));
+    });
+    req.on('error', err => reject(err));
+    if (body) {
+      req.write(body);
+    }
+    req.end();
+  })
+}


### PR DESCRIPTION
- Use Slack API calls with OAuth-token authentication rather than individual webhook URLs. This gives a bit more flexibility (allows the username and channel to be set dynamically, and also allows other API calls to be made, e.g., `channel.list`)
- Overwrite existing chat messages with stage updates (allows for more compact logging)
- Message formatting updates

I've also refactored the HTTP-request code to `slackApi.js`, allowing easier reuse across the various Lambda functions for invoking a Slack-API method.