### PR TITLE
Set fixed timestamps for idempotent Lambda packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,3 +56,11 @@ docker run \
     p5-replay/ffmpeg \
     ffmpeg/build/ffmpeg \
     /root/binaries/ffmpeg/
+
+# Set fixed timestamps for idempotent Lambda packages.
+find \
+    src/binaries \
+    src/node_modules \
+    -type f \
+    -exec \
+    touch -d '2018-01-01T00:00:00Z' {} +


### PR DESCRIPTION
Runs `touch` to set fixed timestamps on the Docker-image-copied files, which helps build/package runs of `aws cloudformation package` avoid re-uploading otherwise-identical Lambda-function packages.