### PR TITLE
Fix cached 403 error response

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -129,6 +129,9 @@ Resources:
           AcmCertificateArn: !Ref APICertificate
           MinimumProtocolVersion: TLSv1
           SslSupportMethod: sni-only
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ErrorCachingMinTTL: 0
         Origins:
           - Id: API
             # ServerlessRestApi is the Implicit API Logical Resource ID created by SAM, Prod is the default Stage name.

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+# Integration-test the asynchronous S3-event flow on a deployed application.
+# Dependencies: bash, curl, jq, ffmpeg (ffplay)
+
+DOMAIN=${DOMAIN?Required}
+
+IFS='|' read uploadURL resultLocation < <(curl -sSL ${DOMAIN}/getS3UploadURL | jq -r '[.uploadURL, .resultLocation] | join("|")')
+curl -sSL --upload-file src/test/fixtures/replay.json "$uploadURL"
+URL="$DOMAIN$resultLocation"
+until curl -X GET -fIL "$URL" >/dev/null 2>&1
+do
+  printf '.'
+  sleep 1
+done
+curl -L "$URL" | ffplay -


### PR DESCRIPTION
S3 returns 403 error on key not found, and CloudFront caches errors for 5 minutes by default. This fix sets the cache TTL to 0 so objects will be found by a polling request as soon as they are made available.

Also adds a simple `test.sh` Bash/curl/jq integration test for the s3-event flow.