### PR TITLE
Prevent broken effects (ie, tacos)

### DIFF
--- a/src/replayToMovie.js
+++ b/src/replayToMovie.js
@@ -17,6 +17,11 @@ const ANIMATIONS = {};
 const WIDTH = 400;
 const HEIGHT = 400;
 
+// Some effects don't currently work, and should be skipped
+const BROKEN_FOREGROUND_EFFECTS = [
+  'raining_tacos'
+];
+
 // Allow binaries to run out of the bundle
 process.env['PATH'] += ':' + process.env['LAMBDA_TASK_ROOT'];
 
@@ -188,7 +193,7 @@ module.exports.renderImages = async (replay, writer) => {
     } else {
       backgroundEffects[frame.bg || 'none'].draw(frame.context);
       p5Inst.drawSprites();
-      if (frame.fg) {
+      if (frame.fg && !BROKEN_FOREGROUND_EFFECTS.includes(frame.fg)) {
         p5Inst.push();
         p5Inst.blendMode(foregroundEffects.blend);
         backgroundEffects[frame.fg].draw(frame.context);

--- a/src/test/fixtures/replay.json
+++ b/src/test/fixtures/replay.json
@@ -1,40 +1,41 @@
 [
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 437.8913962240869,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": -180,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": -180,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -44,40 +45,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 437.8913962240869,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -180,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -180,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -87,40 +89,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 437.8913962240869,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -180,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -180,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 709.7140707389888,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -146,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -146,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -130,83 +177,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 709.7140707389888,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 657.3119349449686,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -110,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -110,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -216,40 +221,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 611.210067958048,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -79,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -79,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -259,40 +265,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 611.210067958048,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 7,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -79,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 7,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -79,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 570.0280924774672,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -57,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -57,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -302,83 +353,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 570.0280924774672,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 530.3565729238308,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -388,40 +397,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 530.3565729238308,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 10,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -42,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 10,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -42,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 532.7436078405808,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -30,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -30,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -431,53 +485,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 532.7436078405808,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 526.5257979825344,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 11,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 11,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 526.5257979825344,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -488,26 +544,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -517,10 +573,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 524.0241299647854,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -531,26 +588,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -560,53 +617,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 524.0241299647854,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 590.3824802256224,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 15,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 590.3824802256224,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -617,26 +676,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -23,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -646,10 +705,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 566.640642918578,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -660,26 +720,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -689,10 +749,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 566.640642918578,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -703,26 +764,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -732,83 +793,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 560.8139687633028,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 527.0928505739552,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 20,
+        "animationFrame": 19,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -24,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -24,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -818,40 +837,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 527.0928505739552,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 20,
+        "animationFrame": 19,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -24,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -24,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -861,10 +881,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 494.52284402928035,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -16,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -16,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 494.52284402928035,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -875,26 +940,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -904,10 +969,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 657.0460594956758,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -918,26 +984,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -9,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -9,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -947,53 +1013,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 657.0460594956758,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 615.0735028233199,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -3,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": -3,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 615.0735028233199,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1004,26 +1072,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim1",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -3,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim1",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -3,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1033,10 +1101,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 561.9852573405095,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1047,26 +1116,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 2,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 2,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1076,10 +1145,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 545.6707545269815,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1090,26 +1160,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 9,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 9,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1119,83 +1189,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 545.6707545269815,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 530.1528414359384,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
+        "animationFrame": 3,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 12,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 12,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1205,10 +1233,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 518.8610786580226,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 13,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 13,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 518.8610786580226,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1219,26 +1292,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1248,10 +1321,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 509.8831270973155,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1262,26 +1336,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 12,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 12,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1291,83 +1365,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 509.8831270973155,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 503.6490854423116,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
+        "animationFrame": 6,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1377,40 +1409,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 503.6490854423116,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
+        "animationFrame": 7,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1420,40 +1453,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 494.299852701935,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
+        "animationFrame": 8,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 7,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 7,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1463,40 +1497,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 491.9504258259078,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
+        "animationFrame": 9,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1506,40 +1541,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 460.55506819385596,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
+        "animationFrame": 10,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 15,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 15,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1549,40 +1585,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 433.5164381991777,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
+        "animationFrame": 11,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 17,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 17,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1592,10 +1629,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 406.8929514721234,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1606,26 +1644,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 20,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 20,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1635,53 +1673,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 406.8929514721234,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 386.2931379183071,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 13,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 386.2931379183071,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1692,26 +1732,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1721,10 +1761,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 369.6413733511568,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1735,26 +1776,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1764,40 +1805,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 369.6413733511568,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 16,
+        "animationFrame": 15,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1807,40 +1849,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 429.9432329136691,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1850,40 +1893,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 442.5729723533664,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 18,
+        "animationFrame": 17,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 20,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 20,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1893,83 +1937,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 442.5729723533664,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 449.4550160114841,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 20,
+        "animationFrame": 18,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -1979,10 +1981,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 449.4550160114841,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 19,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 18,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 18,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 455.4251284705149,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -1993,26 +2040,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2022,10 +2069,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 455.4251284705149,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -2036,26 +2084,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2065,10 +2113,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 456.62470963359044,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -2079,26 +2128,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2108,40 +2157,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 455.7538733321629,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 23,
+        "animationFrame": 22,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 11,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": 1,
+        "rotation": 11,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2151,40 +2201,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 455.7538733321629,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 0,
+        "animationFrame": 23,
         "animationLabel": "anim0",
-        "mirrorX": 1,
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim1",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 11,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim1",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 11,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2194,40 +2245,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 436.5197467555387,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 1,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim1",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 12,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim1",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 12,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2237,40 +2289,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 415.77470373085777,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2280,53 +2333,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 415.77470373085777,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 401.4249079384024,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 2,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 16,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 16,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 401.4249079384024,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -2337,26 +2392,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2366,40 +2421,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 388.8065740837932,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2409,40 +2465,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 377.0323325783044,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2452,40 +2509,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 377.0323325783044,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2495,40 +2553,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 425.4629561623156,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 20,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 20,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2538,83 +2597,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 425.4629561623156,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 447.2721984118637,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2624,40 +2641,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 462.91791308472745,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2667,40 +2685,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 462.91791308472745,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2710,40 +2729,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 464.34678789536247,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2753,40 +2773,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 464.34678789536247,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 8,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 8,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 22,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 471.0232167424268,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2796,83 +2861,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 471.0232167424268,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 480.8766135912357,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2882,10 +2905,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 457.29408171636464,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 11,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 21,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 11,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 21,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 457.29408171636464,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -2896,26 +2964,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2925,10 +2993,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 438.86703603905096,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -2939,26 +3008,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 23,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 23,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -2968,83 +3037,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 438.86703603905096,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 419.64439978966345,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 18,
+        "animationFrame": 17,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 24,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 24,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3054,40 +3081,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 403.8570095010948,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 19,
+        "animationFrame": 18,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3097,40 +3125,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 390.84710584943593,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 19,
+        "animationFrame": 18,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3140,40 +3169,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 390.84710584943593,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 20,
+        "animationFrame": 19,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3183,10 +3213,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 380.201239058661,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 29,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 29,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 380.201239058661,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -3197,26 +3272,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3226,10 +3301,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 413.3906037318512,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -3240,26 +3316,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 30,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 30,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3269,83 +3345,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 413.3906037318512,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 438.4652733699762,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 0,
+        "animationFrame": 23,
         "animationLabel": "anim0",
-        "mirrorX": -1,
+        "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3355,40 +3389,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 463.4446652387495,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 1,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3398,40 +3433,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 463.4446652387495,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3441,40 +3477,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 491.8914855932627,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 3,
+        "animationFrame": 2,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 31,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 31,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3484,10 +3521,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 491.8914855932627,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 2,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 31,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 31,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 511.72793774737215,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -3498,26 +3580,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 0,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 0,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3527,53 +3609,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 511.72793774737215,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 541.3531036211037,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 4,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 31,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 31,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 541.3531036211037,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -3584,26 +3668,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
+        "animationFrame": 2,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 31,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
+        "animationFrame": 2,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 31,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3613,10 +3697,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 515.066769308959,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -3627,26 +3712,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
+        "animationFrame": 3,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 33,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
+        "animationFrame": 3,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 33,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3656,83 +3741,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 515.066769308959,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 490.86879872682186,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
+        "animationFrame": 7,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
+        "animationFrame": 4,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 33,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
+        "animationFrame": 4,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 33,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3742,40 +3785,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 470.0829253635084,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
+        "animationFrame": 8,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
+        "animationFrame": 5,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
+        "animationFrame": 5,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3785,40 +3829,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 470.0829253635084,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
+        "animationFrame": 9,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
+        "animationFrame": 6,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
+        "animationFrame": 6,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3828,40 +3873,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 453.0600217601547,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
+        "animationFrame": 9,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
+        "animationFrame": 6,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 31,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
+        "animationFrame": 6,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 31,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3871,10 +3917,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 453.0600217601547,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 10,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 7,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 31,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 7,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 31,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 439.19239653176885,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -3885,26 +3976,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
+        "animationFrame": 8,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
+        "animationFrame": 8,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -3914,53 +4005,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 439.19239653176885,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 499.39585497273436,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 9,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 30,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 9,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 30,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 499.39585497273436,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -3971,26 +4064,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
+        "animationFrame": 10,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
+        "animationFrame": 10,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4000,10 +4093,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 534.7087184031222,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -4014,26 +4108,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
+        "animationFrame": 11,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
+        "animationFrame": 11,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4043,83 +4137,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 534.7087184031222,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 560.5420003801383,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 16,
+        "animationFrame": 15,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
+        "animationFrame": 12,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
+        "animationFrame": 12,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4129,40 +4181,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 579.7412487000528,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
+        "animationFrame": 13,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
+        "animationFrame": 13,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4172,40 +4225,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 579.7412487000528,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 18,
+        "animationFrame": 17,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
+        "animationFrame": 14,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
+        "animationFrame": 14,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4215,10 +4269,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 594.8429062662648,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 27,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 27,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 594.8429062662648,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -4229,26 +4328,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
+        "animationFrame": 15,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
+        "animationFrame": 15,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4258,10 +4357,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 596.6890886788356,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -4272,26 +4372,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
+        "animationFrame": 16,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 28,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
+        "animationFrame": 16,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 28,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4301,83 +4401,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 596.6890886788356,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 568.3320712954334,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 21,
+        "animationFrame": 20,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
+        "animationFrame": 17,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
+        "animationFrame": 17,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4387,40 +4445,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 542.9528787958826,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 22,
+        "animationFrame": 21,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
+        "animationFrame": 18,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
+        "animationFrame": 18,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 30,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4430,40 +4489,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 523.4745029913997,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 23,
+        "animationFrame": 22,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
+        "animationFrame": 19,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
+        "animationFrame": 19,
+        "animationLabel": "anim2",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4473,40 +4533,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 523.4745029913997,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 0,
+        "animationFrame": 23,
         "animationLabel": "anim0",
-        "mirrorX": 1,
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4516,40 +4577,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 506.9957642258359,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 1,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 28,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 28,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4559,40 +4621,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 506.9957642258359,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 22,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 28,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 22,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 28,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4602,10 +4665,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 513.3196331090517,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -4616,26 +4680,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 23,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 23,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4645,10 +4709,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 568.0253274268105,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -4659,26 +4724,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim2",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4688,40 +4753,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 568.0253274268105,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 26,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4731,40 +4797,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 594.7824565264947,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 25,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 25,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4774,40 +4841,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 615.1395851783907,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 23,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 23,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4817,40 +4885,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 627.2369598840609,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4860,40 +4929,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 627.2369598840609,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 21,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4903,40 +4973,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 636.2530060576123,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -4946,83 +5017,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 636.2530060576123,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 628.472648329954,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 17,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5032,40 +5061,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 604.2131704085483,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5075,40 +5105,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 604.2131704085483,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5118,40 +5149,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 579.2946765773105,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5161,10 +5193,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 579.2946765773105,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 10,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 10,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 560.1354110054348,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -5175,26 +5252,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5204,53 +5281,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 560.1354110054348,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 542.3316203219562,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 15,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 542.3316203219562,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -5261,26 +5340,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5290,40 +5369,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 540.5988826308139,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5333,83 +5413,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 540.5988826308139,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 569.2887776738743,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 18,
+        "animationFrame": 17,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5419,40 +5457,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 575.9001294665298,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 19,
+        "animationFrame": 18,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 12,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 12,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5462,40 +5501,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 575.9001294665298,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 20,
+        "animationFrame": 19,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 12,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 12,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5505,10 +5545,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 577.3302009203743,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.5,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 7,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 7,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 577.3302009203743,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -5519,26 +5604,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 7,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 7,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5548,10 +5633,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 581.4377543246195,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -5562,26 +5648,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 1,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 1,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5591,10 +5677,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 584.0740615764946,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -5605,26 +5692,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": -6,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": -6,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5634,83 +5721,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 584.0740615764946,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6738.324076255251,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 1,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.5808991060236378,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -7,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -7,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5720,40 +5765,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6866.639070815383,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.6432241643717177,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -2,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -2,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5763,40 +5809,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6866.639070815383,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.6432241643717177,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -2,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": -2,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5806,40 +5853,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6717.2088273713825,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 3,
+        "animationFrame": 2,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.6514854804916661,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 2,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim3",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 2,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5849,40 +5897,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 7047.443565203525,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
+        "animationFrame": 3,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.7981637322573067,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5892,40 +5941,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7047.443565203525,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 5,
+        "animationFrame": 4,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.7981637322573067,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5935,40 +5985,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6989.23197346207,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 6,
+        "animationFrame": 5,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8763868040588116,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 15,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 15,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -5978,10 +6029,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6877.3073282951445,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 6,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.8944653976682,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6877.3073282951445,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -5992,26 +6088,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8944653976682,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6021,10 +6117,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7119.641841067339,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6035,26 +6132,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9461292266072507,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6064,53 +6161,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 7119.641841067339,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6965.074937028253,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 8,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.944954061360417,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 5,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 5,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6965.074937028253,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6121,26 +6220,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.944954061360417,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6150,10 +6249,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6787.046223725153,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6164,26 +6264,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9064869473113125,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6193,83 +6293,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6787.046223725153,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6844.322697361672,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
+        "animationFrame": 11,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8827389539689581,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6279,40 +6337,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6844.322697361672,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 13,
+        "animationFrame": 12,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8827389539689581,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6322,40 +6381,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6639.692053804271,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 14,
+        "animationFrame": 13,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8279940122791862,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6365,40 +6425,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6468.948567364177,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 15,
+        "animationFrame": 14,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8049581798121357,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 7,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 7,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6408,10 +6469,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6706.024411826446,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 15,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.971969210579575,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 8,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 8,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6706.024411826446,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6422,26 +6528,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.971969210579575,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 8,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 8,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6451,40 +6557,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6617.717716756203,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0909035360054444,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6494,10 +6601,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6508.78749949984,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6508,26 +6616,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1552690857301422,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6537,10 +6645,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6508.78749949984,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6551,26 +6660,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1552690857301422,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6580,10 +6689,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6371.661147390886,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6594,26 +6704,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1660713910859295,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6623,83 +6733,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6371.661147390886,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6220.054554338286,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 21,
+        "animationFrame": 20,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1386244160916252,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6709,40 +6777,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6220.054554338286,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 22,
+        "animationFrame": 21,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1386244160916252,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 18,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6752,40 +6821,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6714.4153544069295,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 23,
+        "animationFrame": 22,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1668579069889908,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 23,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 23,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6795,10 +6865,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6555.069274384625,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.149400717106428,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 25,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim3",
+        "mirrorX": 1,
+        "rotation": 25,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6555.069274384625,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -6809,26 +6924,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.149400717106428,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 25,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 25,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6838,40 +6953,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6358.352525936456,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 1,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.09897986317621,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 26,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 26,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6881,83 +6997,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6358.352525936456,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6864.739098113186,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1699428889207812,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 25,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 25,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -6967,40 +7041,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6782.720658353184,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 3,
+        "animationFrame": 2,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1865820389790869,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 25,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim3",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 25,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7010,40 +7085,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6603.3932310600985,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
+        "animationFrame": 3,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1599756398992764,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 23,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim3",
+        "mirrorX": -1,
+        "rotation": 23,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7053,40 +7129,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6603.3932310600985,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.1599756398992764,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 23,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 23,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6915.35400412581,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2113815838071702,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 25,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 25,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7096,40 +7217,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6915.35400412581,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2113815838071702,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 25,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 25,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7139,40 +7261,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6816.258733732392,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2170594066521179,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 29,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 29,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7182,40 +7305,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6694.089185961054,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.184184130890265,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 34,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 34,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7225,83 +7349,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6694.089185961054,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6545.846380805033,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1233812359330964,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7311,40 +7393,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6545.846380805033,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1233812359330964,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7354,40 +7437,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6377.963266089297,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.043267431526108,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7397,40 +7481,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6182.536803480212,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9494240580714441,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 45,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 45,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7440,40 +7525,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6989.737417379581,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9981904561429014,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 49,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 49,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7483,40 +7569,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6989.737417379581,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9981904561429014,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 49,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 49,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7526,40 +7613,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6880.773161628175,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 15,
+        "animationFrame": 14,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0047757185287596,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 52,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 52,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7569,40 +7657,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6707.564486446798,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 16,
+        "animationFrame": 15,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9728667948717962,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 54,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 54,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7612,40 +7701,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6707.564486446798,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 15,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9728667948717962,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 54,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 54,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7655,40 +7745,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6728.04977034847,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9464376032034478,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 53,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 53,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7698,40 +7789,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6527.539436146231,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 18,
+        "animationFrame": 17,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8911271546134379,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 50,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 50,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7741,40 +7833,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6527.539436146231,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 19,
+        "animationFrame": 18,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8911271546134379,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 50,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 50,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7784,40 +7877,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6339.833701991456,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 20,
+        "animationFrame": 19,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8657615838669093,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7827,10 +7921,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6558.068692102982,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 1.017511893254184,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6558.068692102982,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -7841,26 +7980,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.017511893254184,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7870,10 +8009,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6470.43650537074,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -7884,26 +8024,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.115339287175527,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 46,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7913,83 +8053,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6470.43650537074,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6347.99056503132,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 0,
+        "animationFrame": 23,
         "animationLabel": "anim0",
-        "mirrorX": -1,
+        "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1576315616924635,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 49,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 49,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -7999,10 +8097,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6207.332109984023,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 1.1532342441667693,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 50,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 50,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6207.332109984023,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -8013,26 +8156,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1532342441667693,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 50,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 50,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8042,10 +8185,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6047.847046920558,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -8056,26 +8200,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1154919233587302,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 51,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 51,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8085,53 +8229,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6047.847046920558,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6405.879493841884,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 2,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.139379760029298,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 53,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 53,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6405.879493841884,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -8142,26 +8288,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.139379760029298,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 0,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 53,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 0,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 53,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8171,10 +8317,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6227.865121515232,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -8185,26 +8332,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1188011375256766,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
+        "animationFrame": 1,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 53,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
+        "animationFrame": 1,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 53,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8214,83 +8361,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6227.865121515232,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6031.598892661442,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 6,
+        "animationFrame": 5,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0666058998492698,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
+        "animationFrame": 2,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 51,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
+        "animationFrame": 2,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 51,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8300,40 +8405,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6031.598892661442,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
+        "animationFrame": 6,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0666058998492698,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
+        "animationFrame": 3,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 51,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
+        "animationFrame": 3,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 51,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8343,40 +8449,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6529.999969174878,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
+        "animationFrame": 7,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0891453991191316,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
+        "animationFrame": 4,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 49,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
+        "animationFrame": 4,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 49,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8386,40 +8493,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6529.999969174878,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
+        "animationFrame": 7,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0891453991191316,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
+        "animationFrame": 5,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 49,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
+        "animationFrame": 5,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 49,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8429,40 +8537,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6356.255670012848,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
+        "animationFrame": 8,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.067450745333365,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
+        "animationFrame": 5,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 45,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
+        "animationFrame": 5,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 45,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8472,40 +8581,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6283.925197494763,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
+        "animationFrame": 9,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0280379614587363,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
+        "animationFrame": 6,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
+        "animationFrame": 6,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8515,40 +8625,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6599.233920438497,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
+        "animationFrame": 10,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0202646952134122,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
+        "animationFrame": 7,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
+        "animationFrame": 7,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8558,40 +8669,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6599.233920438497,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
+        "animationFrame": 11,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0202646952134122,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
+        "animationFrame": 8,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
+        "animationFrame": 8,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8601,40 +8713,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6463.314845520947,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 13,
+        "animationFrame": 12,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9797883285442301,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
+        "animationFrame": 9,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
+        "animationFrame": 9,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8644,40 +8757,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6516.357730786363,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 14,
+        "animationFrame": 13,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9621177224011151,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
+        "animationFrame": 10,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
+        "animationFrame": 10,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8687,40 +8801,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6516.357730786363,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 15,
+        "animationFrame": 14,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9621177224011151,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
+        "animationFrame": 11,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
+        "animationFrame": 11,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8730,40 +8845,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6520.287087249233,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 16,
+        "animationFrame": 14,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9376549036542137,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
+        "animationFrame": 12,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
+        "animationFrame": 12,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8773,40 +8889,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6520.287087249233,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 16,
+        "animationFrame": 15,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9376549036542137,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
+        "animationFrame": 12,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
+        "animationFrame": 12,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8816,40 +8933,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6352.699377514195,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8844229422928707,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
+        "animationFrame": 13,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 43,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
+        "animationFrame": 13,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 43,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8859,10 +8977,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6583.550829270064,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.895269231585813,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 44,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 44,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6583.550829270064,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -8873,26 +9036,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.895269231585813,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
+        "animationFrame": 15,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
+        "animationFrame": 15,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8902,10 +9065,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6354.96112672928,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -8916,26 +9080,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8670053156163121,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
+        "animationFrame": 16,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
+        "animationFrame": 16,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -8945,53 +9109,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6354.96112672928,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6093.019329940587,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.8121192652549556,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 42,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 42,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6093.019329940587,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -9002,26 +9168,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8121192652549556,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
+        "animationFrame": 18,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
+        "animationFrame": 18,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9031,10 +9197,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6685.178357884137,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -9045,26 +9212,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8534121162893739,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
+        "animationFrame": 19,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 39,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
+        "animationFrame": 19,
+        "animationLabel": "anim4",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 39,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9074,83 +9241,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6685.178357884137,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6459.723717743501,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 0,
+        "animationFrame": 23,
         "animationLabel": "anim0",
-        "mirrorX": 1,
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8459971913421535,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 36,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 36,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9160,10 +9285,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6459.723717743501,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.8459971913421535,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 36,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 20,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 36,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6402.15528889467,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -9174,26 +9344,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8477342852762898,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 21,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9203,83 +9373,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6402.15528889467,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6594.376897308317,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0080717707327689,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 22,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 22,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9289,40 +9417,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6492.40986335384,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 3,
+        "animationFrame": 2,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1193940519358492,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 23,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 34,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 23,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 34,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9332,40 +9461,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6365.944777251859,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
+        "animationFrame": 3,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.178550382698045,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 37,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim4",
+        "mirrorX": -1,
+        "rotation": 37,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9375,40 +9505,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6365.944777251859,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.178550382698045,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 37,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 37,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6207.002707626404,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1871235329244394,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 38,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 38,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9418,83 +9593,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6207.002707626404,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6028.5148515263945,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.158924141739615,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9504,40 +9637,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6028.5148515263945,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.158924141739615,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9547,40 +9681,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6088.367739320746,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1289323364734773,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9590,40 +9725,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 5925.693955009075,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0776582264507035,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9633,40 +9769,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 5925.693955009075,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0776582264507035,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9676,40 +9813,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 5696.085323799875,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0056848527503504,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 38,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 38,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9719,40 +9857,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6183.5418209672225,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0215191306334415,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 36,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 36,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9762,40 +9901,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6024.747157129231,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0002569375953154,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9805,40 +9945,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6024.747157129231,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0002569375953154,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 32,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9848,40 +9989,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 5828.330763378158,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 15,
+        "animationFrame": 14,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9512787723417272,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9891,40 +10033,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 5828.330763378158,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 15,
+        "animationFrame": 14,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9512787723417272,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9934,40 +10077,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6574.238925226941,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 16,
+        "animationFrame": 15,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.98936898246584,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 28,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 28,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -9977,40 +10121,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6438.92701852655,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9824011016225719,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 31,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 31,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10020,40 +10165,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6438.92701852655,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 18,
+        "animationFrame": 17,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9824011016225719,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 31,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 31,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10063,40 +10209,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6261.598783970951,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 19,
+        "animationFrame": 18,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9409519945970194,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 34,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 34,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10106,10 +10253,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6038.032042305425,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 19,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 0.8750746221487664,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 16,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 37,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 16,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 37,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6038.032042305425,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -10120,26 +10312,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8750746221487664,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 37,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 37,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10149,10 +10341,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 5795.257944129993,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -10163,26 +10356,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.792282904783324,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 39,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10192,83 +10385,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 5795.257944129993,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6095.708830287499,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 23,
+        "animationFrame": 22,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8193400997349132,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10278,40 +10429,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6095.708830287499,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 23,
+        "animationFrame": 22,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8193400997349132,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10321,40 +10473,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6160.758452566588,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 0,
+        "animationFrame": 23,
         "animationLabel": "anim0",
-        "mirrorX": -1,
+        "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8336970973416988,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10364,40 +10517,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6124.099100626106,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 1,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.822514015055174,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 45,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 45,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10407,40 +10561,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6124.099100626106,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.822514015055174,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 45,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 45,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10450,40 +10605,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 7121.486469312627,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 3,
+        "animationFrame": 2,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9610914311891159,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim5",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 44,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10493,10 +10649,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7020.261159501068,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.0298423800350593,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 0,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 0,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7020.261159501068,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -10507,26 +10708,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0298423800350593,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10536,10 +10737,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6915.2355749890285,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -10550,26 +10752,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.050536039956509,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 38,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 38,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10579,83 +10781,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6915.2355749890285,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6908.034783881765,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
+        "animationFrame": 6,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1853752279695562,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 39,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 39,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10665,10 +10825,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6908.034783881765,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 6,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.1853752279695562,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 39,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 3,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 39,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6812.878015379242,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -10679,26 +10884,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2797626595786895,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 4,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10708,10 +10913,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6812.878015379242,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -10722,26 +10928,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2797626595786895,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10751,10 +10957,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6693.107199514919,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -10765,26 +10972,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3397648000251206,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10794,83 +11001,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6693.107199514919,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6637.181766906325,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
+        "animationFrame": 10,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3518440879814966,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 7,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10880,40 +11045,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6582.751543577504,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 12,
+        "animationFrame": 11,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3312648462571897,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10923,40 +11089,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6582.751543577504,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 13,
+        "animationFrame": 12,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3312648462571897,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 41,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -10966,40 +11133,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 6791.591787422127,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 14,
+        "animationFrame": 13,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3437615502388827,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 10,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11009,40 +11177,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6708.961812457535,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 15,
+        "animationFrame": 14,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3222691340207402,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 44,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 44,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11052,10 +11221,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6708.961812457535,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.3222691340207402,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 44,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 12,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 44,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6622.905787541973,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11066,26 +11280,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2783089113677208,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 46,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 46,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11095,83 +11309,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6622.905787541973,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 7025.826294739158,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 17,
+        "animationFrame": 16,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3319653384278025,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 47,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 47,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11181,10 +11353,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6961.331876415549,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 17,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.3403443905285388,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 45,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 45,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 6961.331876415549,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11195,26 +11412,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3403443905285388,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 45,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 45,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11224,10 +11441,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 6873.27199008702,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11238,26 +11456,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3166186610691804,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11267,83 +11485,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 6873.27199008702,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 7239.775022289703,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 21,
+        "animationFrame": 20,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3412844917356717,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11353,10 +11529,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7182.32032425294,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 21,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.3286283628460902,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 18,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 42,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 18,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 42,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7182.32032425294,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11367,26 +11588,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.3286283628460902,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11396,40 +11617,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7094.730454817596,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 23,
+        "animationFrame": 22,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.281978870699511,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11439,10 +11661,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7094.730454817596,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11453,26 +11676,26 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.281978870699511,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 20,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 43,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11482,10 +11705,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7347.472665939546,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11496,26 +11720,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2764118402643148,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim5",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 43,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim5",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 43,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11525,10 +11749,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7284.778778315308,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11539,26 +11764,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2369367618031686,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim5",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim5",
         "mirrorX": 1,
-        "rotation": 0,
+        "rotation": 42,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11568,53 +11793,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 7284.778778315308,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7197.305914374598,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 2,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 1.1710504027597417,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 40,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 23,
+        "animationLabel": "anim5",
+        "mirrorX": 1,
+        "rotation": 40,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7197.305914374598,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -11625,26 +11852,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1710504027597417,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim5",
+        "mirrorX": -1,
+        "rotation": 40,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11654,40 +11881,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7412.745099637376,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 13,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.193463601886445,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 37,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 1,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 37,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11697,83 +11925,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 7412.745099637376,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7335.600897291357,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1721308944201705,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 33,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 33,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11783,40 +11969,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7335.600897291357,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 14,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1721308944201705,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 33,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 6,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 33,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11826,40 +12013,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7535.147139364475,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 15,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1830670017725797,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 7,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 3,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 27,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11869,40 +12057,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7535.147139364475,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 16,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.1830670017725797,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 4,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 27,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 4,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 27,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7504.411746389122,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 17,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1616610420713958,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 8,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 5,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11912,83 +12145,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 7504.411746389122,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 9,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7422.761750104087,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 18,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1090986007894965,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 10,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 10,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 6,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 10,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -11998,40 +12189,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7422.761750104087,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 19,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.1090986007894965,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 7,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 10,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 7,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 10,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7560.544437007171,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 20,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2059812738815514,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 5,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 11,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 8,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 5,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12041,83 +12277,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 7560.544437007171,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 12,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7518.1508340961445,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 21,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.272315618016381,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 5,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 13,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 9,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 5,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12127,40 +12321,85 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7518.1508340961445,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 1.272315618016381,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 10,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 5,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 10,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 5,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7445.330444881524,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
+        "animationFrame": 22,
+        "animationLabel": "anim1",
+        "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2864961917938227,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 7,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 11,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 7,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12170,53 +12409,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 7445.330444881524,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 14,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7472.377996210831,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 14,
+        "animationLabel": "anim0",
+        "mirrorX": 1,
+        "rotation": 0,
+        "scale": 1.282315840879699,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 11,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 11,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 11,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 11,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7472.377996210831,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -12227,26 +12468,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.282315840879699,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 11,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 15,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 12,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 11,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12256,10 +12497,11 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7394.4202453071075,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -12270,26 +12512,26 @@
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.2427120385881474,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 14,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 16,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 13,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 14,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12299,83 +12541,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
-    "context": {
-      "isPeak": false,
-      "centroid": 7394.4202453071075,
-      "bpm": "133",
-      "artist": "Spritlab Suzy",
-      "title": "Synthesize"
-    },
-    "sprites": [
-      {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "BEAR",
-        "x": 200,
-        "y": 100
-      },
-      {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "CAT",
-        "x": 100,
-        "y": 300
-      },
-      {
-        "animationFrame": 17,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
-        "scale": 1,
-        "style": "ROBOT",
-        "x": 300,
-        "y": 300
-      }
-    ]
-  },
-  {
-    "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7313.426631020757,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 18,
+        "animationFrame": 17,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1804576362145083,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 18,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 14,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12385,40 +12585,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7262.758754114721,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 19,
+        "animationFrame": 18,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1151167428596835,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 19,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 15,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12428,40 +12629,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7262.758754114721,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 20,
+        "animationFrame": 19,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.1151167428596835,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 20,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 16,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12471,40 +12673,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7135.103608447953,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 21,
+        "animationFrame": 20,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0322502044399382,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 21,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 17,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12514,40 +12717,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": true,
       "centroid": 7368.166100818514,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 22,
+        "animationFrame": 21,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0225774680018502,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12557,40 +12761,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7368.166100818514,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 22,
+        "animationFrame": 21,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 1.0225774680018502,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 22,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 18,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 15,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12600,40 +12805,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7358.570622352072,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 23,
+        "animationFrame": 22,
         "animationLabel": "anim0",
         "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9902289570114883,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 14,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 23,
-        "animationLabel": "anim0",
-        "mirrorX": 1,
-        "rotation": 0,
+        "animationFrame": 19,
+        "animationLabel": "anim6",
+        "mirrorX": -1,
+        "rotation": 14,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12643,40 +12849,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7247.397839785063,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 0,
+        "animationFrame": 23,
         "animationLabel": "anim0",
-        "mirrorX": -1,
+        "mirrorX": 1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.930258399591116,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 0,
-        "animationLabel": "anim0",
+        "animationFrame": 20,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12686,40 +12893,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7247.397839785063,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 1,
+        "animationFrame": 0,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.930258399591116,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 13,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 1,
-        "animationLabel": "anim0",
+        "animationFrame": 21,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 13,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12729,40 +12937,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7429.198846541548,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 2,
+        "animationFrame": 1,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9522561125487308,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 16,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 2,
-        "animationLabel": "anim0",
+        "animationFrame": 22,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 16,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12772,40 +12981,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7358.208130079441,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 3,
+        "animationFrame": 2,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9331227708495087,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 3,
-        "animationLabel": "anim0",
+        "animationFrame": 23,
+        "animationLabel": "anim6",
         "mirrorX": -1,
-        "rotation": 0,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12815,40 +13025,41 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7358.208130079441,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
     },
     "sprites": [
       {
-        "animationFrame": 4,
+        "animationFrame": 3,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.9331227708495087,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 19,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
-        "animationFrame": 4,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 0,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 19,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,
@@ -12858,10 +13069,55 @@
   },
   {
     "bg": "disco",
-    "fg": null,
+    "fg": "rain",
     "context": {
       "isPeak": false,
       "centroid": 7251.4394704760125,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
+        "animationFrame": 4,
+        "animationLabel": "anim0",
+        "mirrorX": -1,
+        "rotation": 0,
+        "scale": 0.8820451959525819,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 23,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 1,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 23,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7251.4394704760125,
+      "backgroundColor": "#ffffcc",
       "bpm": "133",
       "artist": "Spritlab Suzy",
       "title": "Synthesize"
@@ -12872,26 +13128,70 @@
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
-        "scale": 1,
+        "scale": 0.8820451959525819,
         "style": "BEAR",
         "x": 200,
         "y": 100
       },
       {
-        "animationFrame": 5,
-        "animationLabel": "anim0",
-        "mirrorX": -1,
-        "rotation": 0,
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 23,
         "scale": 1,
         "style": "CAT",
         "x": 100,
         "y": 300
       },
       {
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 23,
+        "scale": 1,
+        "style": "ROBOT",
+        "x": 300,
+        "y": 300
+      }
+    ]
+  },
+  {
+    "bg": "disco",
+    "fg": "rain",
+    "context": {
+      "isPeak": false,
+      "centroid": 7365.513797138073,
+      "backgroundColor": "#ffffcc",
+      "bpm": "133",
+      "artist": "Spritlab Suzy",
+      "title": "Synthesize"
+    },
+    "sprites": [
+      {
         "animationFrame": 5,
         "animationLabel": "anim0",
         "mirrorX": -1,
         "rotation": 0,
+        "scale": 0.8540529188760786,
+        "style": "BEAR",
+        "x": 200,
+        "y": 100
+      },
+      {
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 24,
+        "scale": 1,
+        "style": "CAT",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "animationFrame": 2,
+        "animationLabel": "anim6",
+        "mirrorX": 1,
+        "rotation": 24,
         "scale": 1,
         "style": "ROBOT",
         "x": 300,


### PR DESCRIPTION
Don't try to draw effects that are known to look bad on the lambda. Right now, this is just tacos:

![video](https://user-images.githubusercontent.com/244100/48103149-d4920d00-e1e2-11e8-819c-609a620977cb.gif)

Also update the text fixture to include a more complete representation of all the different things we can do:

![video](https://user-images.githubusercontent.com/244100/48103194-f7bcbc80-e1e2-11e8-9ac1-b9bef6920cae.gif)
