### PR TITLE
Respond to "404" errors with an mp4

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -133,6 +133,8 @@ Resources:
         CustomErrorResponses:
           - ErrorCode: 403
             ErrorCachingMinTTL: 0
+            ResponseCode: 200
+            ResponsePagePath: "/videos/404.mp4"
         Origins:
           - Id: API
             # ServerlessRestApi is the Implicit API Logical Resource ID created by SAM, Prod is the default Stage name.


### PR DESCRIPTION
"404" in quotes because "file not found" errors manifest in S3 as 403
errors. We want to respond to those with a video showing the "default"
dance, so nothing is obviously broken in social share prior to the video
being fully generated.