### PR TITLE
Remove 404 fallback video

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -133,8 +133,6 @@ Resources:
         CustomErrorResponses:
           - ErrorCode: 403
             ErrorCachingMinTTL: 0
-            ResponseCode: 200
-            ResponsePagePath: "/videos/404.mp4"
         Origins:
           - Id: API
             # ServerlessRestApi is the Implicit API Logical Resource ID created by SAM, Prod is the default Stage name.


### PR DESCRIPTION
Since we're moving away from social share, this is less necessary. And since we're moving toward clientside video download, this makes it harder to detect when the video is ready to be downloaded.