### PR TITLE
Fix canvas freeze

### DIFF
--- a/src/replayToMovie.js
+++ b/src/replayToMovie.js
@@ -168,6 +168,7 @@ module.exports.renderImages = async (replay, writer, parentSegment) => {
   // We have to create a new canvas on every request, otherwise under periods
   // of high traffic the canvas can get into a state where it "freezes" and
   // repeats a single frame for the length of an entire video.
+  // See https://github.com/code-dot-org/dance-party/issues/514 for more context
   const canvas = window.document.createElement('canvas');
   p5Inst._renderer = new P5.Renderer2D(canvas, p5Inst, false);
   p5Inst._renderer.resize(WIDTH, HEIGHT);

--- a/src/replayToMovie.js
+++ b/src/replayToMovie.js
@@ -81,14 +81,6 @@ const p5Inst = new P5(function (p5obj) {
   p5obj.height = HEIGHT;
 });
 
-// Create our emulated canvas.
-const canvas = window.document.createElement('canvas');
-p5Inst._renderer = new P5.Renderer2D(canvas, p5Inst, false);
-p5Inst._renderer.resize(WIDTH, HEIGHT);
-
-const backgroundEffects = new Effects(p5Inst, 1);
-const foregroundEffects = new Effects(p5Inst, 0.8);
-
 function loadNewSpriteSheet(spriteName, moveName) {
   debug(`loading ${spriteName}@${moveName}`);
 
@@ -171,6 +163,17 @@ module.exports.renderImages = async (replay, writer, parentSegment) => {
   const sprites = [];
   let lastBackground;
   let lastForeground;
+
+  // Create our emulated canvas.
+  // We have to create a new canvas on every request, otherwise under periods
+  // of high traffic the canvas can get into a state where it "freezes" and
+  // repeats a single frame for the length of an entire video.
+  const canvas = window.document.createElement('canvas');
+  p5Inst._renderer = new P5.Renderer2D(canvas, p5Inst, false);
+  p5Inst._renderer.resize(WIDTH, HEIGHT);
+
+  const backgroundEffects = new Effects(p5Inst, 1);
+  const foregroundEffects = new Effects(p5Inst, 0.8);
 
   replay.length = Math.min(replay.length, FRAME_LIMIT);
 


### PR DESCRIPTION
Fixes https://github.com/code-dot-org/dance-party/issues/514

Depends on https://github.com/code-dot-org/p5-replay/pull/49

We're still not exactly sure what's going on, but creating a new canvas for every request (rather than reusing the same in-memory canvas for every request) seems to prevent the issue where all videos generated for all users are using a single frozen frame for the entire video.