### PR TITLE
download S3 data directly into JSON

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -144,5 +144,5 @@ async function getJSONFromS3(Bucket, Key) {
   }
 
   const result = await s3.getObject({Bucket, Key}).promise();
-  return JSON.parse(result);
+  return JSON.parse(result.Body);
 }


### PR DESCRIPTION
do everything in memory rather than taking an unnecessary trip through the filesystem