### PR TITLE
only attempt to render sprites that have skins and dances set

### DIFF
--- a/src/replayToMovie.js
+++ b/src/replayToMovie.js
@@ -218,6 +218,13 @@ module.exports.renderImages = async (replay, writer, parentSegment) => {
     for (let i = 0; i < frame.sprites.length; i++) {
       const entry = frame.sprites[i];
 
+      if (!(entry.style && entry.animationLabel)) {
+        // A sprite was created without a dancer skin or a dance animation;
+        // this could be because a non-dancer sprite was incorrectly logged as
+        // a dancer.
+        continue;
+      }
+
       if (!sprites[i]) {
         sprites[i] = p5Inst.createSprite();
         await loadSprite(entry.style);


### PR DESCRIPTION
so the service doesn't break when non-Dancer sprites get accidentally added to the replay log (as happens with the quads effect: https://github.com/code-dot-org/dance-party/blob/2688bae80b5e2695a53f9250b6e19fe91ac9de3c/src/Effects.js#L815)