### PR TITLE
Fix content-type of video files exported from a Dance Party project

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -137,7 +137,7 @@ function upload(Bucket, Key, Body, ContentEncoding, ContentType) {
     Key: Key,
     Body: Body,
     ContentEncoding: ContentEncoding,
-    ContentType: ContentType
+    ContentType: 'video/mp4' // This ensures that when the Object is served up via HTTP by S3, the content-type is set correctly.
   }).promise();
 }
 


### PR DESCRIPTION
When a browser (or other HTTP client) fetches a Dance Party video exported from a Dance Party project, our systems are setting the Content-Type in the HTTP Response to `application-octetstream`. While the filename is set to `dance_party.mp4`, some HTTP clients may not recognize the content we are serving up is a video. Twilio, specifically, when fetching a Dance Party video to send on our behalf as an MMS message, does not recognize it as a video.