### PR TITLE
Enable HTTP logging for Dance Party video export

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -13,6 +13,9 @@ Parameters:
     ConstraintDescription: Must end with trailing dot `.`
   DomainName:
     Type: String
+  LogBucket:
+    Type: String
+    Default: cdo-logs.s3.amazonaws.com
 
 Globals:
   Function:
@@ -133,6 +136,10 @@ Resources:
         CustomErrorResponses:
           - ErrorCode: 403
             ErrorCachingMinTTL: 0
+        Logging:
+          Bucket: !Ref LogBucket
+          IncludeCookies: false
+          Prefix: !Ref DomainName
         Origins:
           - Id: API
             # ServerlessRestApi is the Implicit API Logical Resource ID created by SAM, Prod is the default Stage name.


### PR DESCRIPTION
When a student's web browser sends a request to download the video exported from their DanceParty project, the HTTP request is sent to a CloudFront Distribution, which sources the video file from an S3 Bucket configured for static web site hosting. Enable HTTP logging on this CloudFront Distribution to gather better metrics on usage of the Dance Party video export feature.

Currently usage is hard to measure, because it appears that as a performance optimization measure, we trigger rendering of the video when a student opens the Project Share dialog regardless of whether they plan to click on the Download Animation button later. It appears we do this to ensure to avoid making the student wait when they click Download button (average render time is ~6 seconds and most of our HTTP requests are served up in <0.3 s).

I suspect that a very small percentage of rendered videos are actually being downloaded by students and that with metrics showing that, we could switch this feature to render on demand and provide some progress animation to the student to indicate that their video is being prepared. This could reduce Lamba resource consumption, and also potentially enable us to render a video that aligns exactly with an existing licensed Sound on TikTok.

